### PR TITLE
폰트 적용안되는 문제, 음료명 말줄임 함수 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,8 +33,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="kr">
-      <body className={`layout ${pretendard.className}`}>
+    <html lang="kr" className={pretendard.className}>
+      <body className="layout">
         <div id="modal-root">
           <Modals />
         </div>

--- a/src/container/home/HomeMainContainer.tsx
+++ b/src/container/home/HomeMainContainer.tsx
@@ -30,14 +30,16 @@ const HomeMainContainer = () => {
 
     getUserData();
 
+    // 시간대별 모달 출력: 시연 영상 촬영하기 위해 잠시 주석 처리
+
     // 12시 30분부터 5시 사이에 음료 추천 모달 띄움
-    const modalVisible = dayjs().isBetween(
-      dayjs().startOf('day').add(12, 'hour').add(30, 'minute'),
-      dayjs().startOf('day').add(17, 'hour'),
-    );
+    // const modalVisible = dayjs().isBetween(
+    //   dayjs().startOf('day').add(12, 'hour').add(30, 'minute'),
+    //   dayjs().startOf('day').add(17, 'hour'),
+    // );
     const hideModalTime = localStorage.getItem('hideModal');
 
-    if (!modalVisible) return;
+    // if (!modalVisible) return;
 
     if (!hideModalTime || (hideModalTime && +hideModalTime < +dayjs())) {
       openModal();

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -34,7 +34,7 @@
 }
 
 :root {
-  --toastify-font-family: Pretendard;
+  --toastify-font-family: var(--font-pretendard);
 }
 
 .Toastify__toast {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -13,5 +13,5 @@ export const ellipsisText = (text: string, maxLength: number) => {
     slicedText += ch;
   }
 
-  return len < 10 ? slicedText : slicedText + '...';
+  return text === slicedText ? slicedText : slicedText + '...';
 };


### PR DESCRIPTION
## 작업 내용
- 토스트메시지와 전체 페이지에 폰트 적용안되는 문제 해결
- 음료명 공백 제외 10자 `초과`일 때만 말줄임표시 (기존엔 10자일 때도 뒤에 ... 표시 되었음)