### PR TITLE
카페인 달력 데이터 형식 수정, 유효하지 토큰일 때의 처리 추가

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -25,14 +25,14 @@ apiInstance.interceptors.response.use(
     return response.data;
   },
   (error) => {
-    // TODO: 토큰이 유효하지 않은 경우 저장된 토큰 삭제, 현재 500에러로 넘어와서 서버 측 작업 완료 후 수정 필요
-    // if (error.response.status === 401) {
-    //   if (typeof window !== 'undefined') {
-    //     localStorage.removeItem('accessToken');
-    //     localStorage.removeItem('refreshToken');
-    //     window.location.reload();
-    //   }
-    // }
+    // 토큰이 유효하지 않은 경우 저장된 토큰 삭제
+    if (error.response.status === 401) {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.reload();
+      }
+    }
 
     return Promise.reject(error.response);
   },

--- a/src/components/caffeineCalendar/CaffeineCalendar.tsx
+++ b/src/components/caffeineCalendar/CaffeineCalendar.tsx
@@ -32,7 +32,7 @@ const CaffeineCalendar = ({ selectedDate, onSelect }: CaffeineCalendarProps) => 
   const addTitleContent = ({ date }: { date: Date }) => {
     if (!thisMonthData) return;
 
-    const curDate = date.getDate().toString();
+    const curDate = dayjs(date).format('YYYY-MM-DD');
     const status = thisMonthData.date[curDate];
 
     if (!status) return null;

--- a/src/components/caffeineCalendar/MonthComparisonMessage.tsx
+++ b/src/components/caffeineCalendar/MonthComparisonMessage.tsx
@@ -2,7 +2,7 @@ const MonthComparisonMessage = ({ status }: { status: string }) => {
   let message = '';
 
   if (status === '없음') message = '지난 달의 데이터가 없어요';
-  else if (status === '같음') message = '지난 달과 카페인 섭취량이 같아요';
+  else if (status === '동일') message = '지난 달과 카페인 섭취량이 같아요';
   else message = '지난 달보다 카페인 섭취량이 ';
 
   return (

--- a/src/components/home/drinkHistory/DrinkHistorySwiper.tsx
+++ b/src/components/home/drinkHistory/DrinkHistorySwiper.tsx
@@ -10,19 +10,20 @@ const DrinkHistorySwiper = ({ slideData }: { slideData: Menu[] }) => {
   return (
     <Swiper
       slidesPerView="auto"
+      slidesOffsetBefore={20}
       spaceBetween={8}
       freeMode={true}
       modules={[FreeMode]}
       slidesOffsetAfter={20}
-      className="!m-0 !w-full !pb-8"
+      className="!pb-8"
     >
       {slideData.map((data) => (
-        <SwiperSlide key={data.menuNo} className="mr-2 !w-fit first:ml-5 last:mr-0">
+        <SwiperSlide key={data.menuNo}>
           <DrinkHistoryCard drinkHistoryData={data} />
         </SwiperSlide>
       ))}
       {slideData.length === 1 && (
-        <SwiperSlide className="!w-fit">
+        <SwiperSlide>
           <DrinkHistoryCard />
         </SwiperSlide>
       )}


### PR DESCRIPTION
## 작업 내용
- 서버로 요청 보낸 후 응답코드가 401일 때(토큰이 유효하지 않을 때) 로컬스토리지에 저장되어 있는 토큰 삭제 후 새로고침 하도록 추가했습니다.
- 카페인 달력 기록에서 지난/다음 달에 있는 날짜와 같을 경우 중복으로 카페인 상태 타일이 보여지는 문제가 있어 '년-월-일'의 형태로 수정 요청하여 수정했습니다.